### PR TITLE
Add Turbo Model Support and Configuration Updates

### DIFF
--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -494,7 +494,7 @@
       "languageVersion": "3.3"
     }
   ],
-  "generated": "2025-09-01T18:27:40.007578Z",
+  "generated": "2025-09-02T17:21:50.276837Z",
   "generator": "pub",
   "generatorVersion": "3.6.1",
   "flutterRoot": "file:///Users/statecs/Flutter/flutter",

--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -494,7 +494,7 @@
       "languageVersion": "3.3"
     }
   ],
-  "generated": "2025-08-31T22:52:33.491056Z",
+  "generated": "2025-09-01T18:27:40.007578Z",
   "generator": "pub",
   "generatorVersion": "3.6.1",
   "flutterRoot": "file:///Users/statecs/Flutter/flutter",

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ and Android
 2. Support Android 5.0+ & iOS 13+ & MacOS 11+
 3. It is optimized and fast
 
-Supported models: tiny、base、small、medium、large-v1、large-v2
+Supported models: tiny、base、small、medium、large-v1、large-v2, large-v3-turbo
 
-Recommended Models：base、small、medium
+Recommended Models：base、small、medium, turbo
 
 All models have been actually tested, test devices: Android: Google Pixel 7 Pro, iOS: M1 iOS
 simulator，MacOS: M1 MacBookPro & M2 MacMini

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ android {
     if (project.android.hasProperty("namespace")) {
         namespace "com.devac.whisper_flutter_coreml"
     }
-    ndkVersion "27.0.11902837"
+    ndkVersion "26.1.10909125"
 
     compileSdk 34
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -33,7 +33,7 @@ if (flutterVersionName == null) {
 android {
     namespace "com.example.whisper"
     compileSdk 34//compileSdkVersion flutter.compileSdkVersion
-    ndkVersion "27.0.11902837"//ndkVersion flutter.ndkVersion
+    ndkVersion "26.1.10909125"//ndkVersion flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,10 +1,4 @@
-/*
- * Copyright (c) 田梓萱[小草林] 2021-2024.
- * All Rights Reserved.
- * All codes are protected by China's regulations on the protection of computer software, and infringement must be investigated.
- * 版权所有 (c) 田梓萱[小草林] 2021-2024.
- * 所有代码均受中国《计算机软件保护条例》保护，侵权必究.
- */
+
 
 import "dart:io";
 

--- a/ios/whisper_flutter_coreml.podspec
+++ b/ios/whisper_flutter_coreml.podspec
@@ -27,7 +27,7 @@ A Flutter FFI plugin for Whisper.cpp.
   # Flutter.framework does not contain a i386 slice.
   s.xcconfig = {
       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
-      'GCC_PREPROCESSOR_DEFINITIONS' => 'WHISPER_USE_COREML=1 NDEBUG=1',
+      'GCC_PREPROCESSOR_DEFINITIONS' => 'WHISPER_USE_COREML=1 WHISPER_COREML_ALLOW_FALLBACK=1 NDEBUG=1',
       'CLANG_ENABLE_OBJC_ARC' => 'YES',
   }
   s.library = 'c++'

--- a/lib/download_model.dart
+++ b/lib/download_model.dart
@@ -25,7 +25,7 @@ enum WhisperModel {
   small("small"),
 
   /// turbo model for all languages
-  turbo("large-v3-turbo-q5_0"),
+  turbo("large-v3-turbo"),
 
   /// medium model for all languages
   medium("medium"),

--- a/lib/download_model.dart
+++ b/lib/download_model.dart
@@ -25,7 +25,7 @@ enum WhisperModel {
   small("small"),
 
   /// turbo model for all languages
-  turbo("large-v3-turbo"),
+  turbo("large-v3-turbo-q5_0"),
 
   /// medium model for all languages
   medium("medium"),

--- a/lib/download_model.dart
+++ b/lib/download_model.dart
@@ -24,6 +24,9 @@ enum WhisperModel {
   /// small model for all languages
   small("small"),
 
+  /// turbo model for all languages
+  turbo("large-v3-turbo"),
+
   /// medium model for all languages
   medium("medium"),
 

--- a/macos/whisper_flutter_coreml.podspec
+++ b/macos/whisper_flutter_coreml.podspec
@@ -9,9 +9,9 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 A Flutter FFI plugin for Whisper.cpp.
                        DESC
-  s.homepage         = 'https://www.xcl.ink'
+  s.homepage         = 'https://cstate.se'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { '田梓萱' => 'zixuanxcl@gmail.com' }
+  s.author           = { 'statecs' => 'hello@cstate.se' }
   s.source           = { :path => '.' }
 
   # This will ensure the source files in Classes/ are included in the native

--- a/macos/whisper_flutter_coreml.podspec
+++ b/macos/whisper_flutter_coreml.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'whisper_flutter_coreml'
-  s.version          = '0.0.1'
+  s.version          = '1.0.1'
   s.summary          = 'A Flutter FFI plugin for Whisper.cpp.'
   s.description      = <<-DESC
 A Flutter FFI plugin for Whisper.cpp.

--- a/macos/whisper_flutter_coreml.podspec
+++ b/macos/whisper_flutter_coreml.podspec
@@ -27,7 +27,7 @@ A Flutter FFI plugin for Whisper.cpp.
   # Flutter.framework does not contain a i386 slice.
   s.xcconfig = {
       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
-      'GCC_PREPROCESSOR_DEFINITIONS' => 'WHISPER_USE_COREML=1 NDEBUG=1',
+      'GCC_PREPROCESSOR_DEFINITIONS' => 'WHISPER_USE_COREML=1 WHISPER_COREML_ALLOW_FALLBACK=1 NDEBUG=1',
       'CLANG_ENABLE_OBJC_ARC' => 'YES',
   }
   s.library = 'c++'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: whisper_flutter_coreml
 description: A flutter library for offline speech-to-text conversion which use whisper.cpp models implementation for Android、iOS、macOS.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/statecs/whisper_flutter_coreml
 issue_tracker: https://github.com/statecs/whisper_flutter_coreml/issues
 homepage: https://github.com/statecs/whisper_flutter_coreml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A flutter library for offline speech-to-text conversion which use w
 version: 1.0.1
 repository: https://github.com/statecs/whisper_flutter_coreml
 issue_tracker: https://github.com/statecs/whisper_flutter_coreml/issues
-homepage: https://github.com/statecs/whisper_flutter_coreml
+homepage: https://pub.dev/packages/whisper_flutter_coreml
 
 platforms:
   android:


### PR DESCRIPTION
# Add Turbo Model Support and Configuration Updates

This PR adds support for the large-v3-turbo Whisper model and updates build configurations for better compatibility.

## Changes

- Added `turbo` model to `WhisperModel` enum for the large-v3-turbo variant
- Updated README to include turbo in supported and recommended models  
- Added `WHISPER_COREML_ALLOW_FALLBACK=1` preprocessor definition for iOS/macOS builds
- Reverted Android NDK version from 27.0.11902837 to 26.1.10909125 for stability
- Updated package version to 1.0.1
- Updated author information and homepage links
- Cleaned up example code copyright headers

## Benefits

- Turbo model provides faster inference whilst maintaining good accuracy
- CoreML fallback ensures better device compatibility  
- NDK rollback addresses potential build issues with newer versions

The turbo model is particularly useful for real-time applications where speed is prioritised over maximum accuracy.