### PR TITLE
1.0.4: cache whisper context, releaseContext, v3-family model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,15 @@
-## 1.0.0
+## 1.0.4
 
-* Optimizing performance
-* Update Dependencies
-* AGP8+ compatible
-* Support custom model download Host
-* See the example project for more details.
-
-## 1.0.1
-
-* Update Gradle version to 8.4.2
-* Update NDK version to 27.0.11902837
-* Support MacOS
-
+* Support Whisper v3-family models (`large-v3`, `large-v3-turbo`): the vendored whisper.cpp predated v3 and decoded these models into gibberish — `is_multilingual()` rejected the 51866-token v3 vocab (shifting every special token id), and the mel spectrogram was hardcoded to 80 bins while v3 encoders expect 128
+* Fix CoreML encoder lookup for quantized models: the Dart downloader kept the `-qX_Y` suffix in the `.mlmodelc` name, but whisper.cpp strips it when resolving the encoder path, so turbo never found its downloaded CoreML encoder and silently fell back to CPU
+* Cache the whisper context across requests instead of reloading model weights and the CoreML encoder on every transcription
+* Add `Whisper.releaseContext()` to free the cached native context and reclaim memory; the next `transcribe()` reloads the model automatically
+* Update Android build to NDK 28.0.12433566 and compileSdk 36 (16 KB page-size alignment required by Google Play for targetSdk 35+)
 
 ## 1.0.3
 
 * Fix heap corruption on iOS: CoreML encoder exception handlers cleared a hardcoded 7.68MB (large-model size) instead of the actual output buffer, overrunning smaller models' buffers and causing delayed EXC_BAD_ACCESS crashes
 * Fix silently dropped encoder output on iOS: copy-loop bounds check used the logical element count instead of the stride-padded physical size, zeroing the last encoder-state rows on every CoreML batch
-* Update Android build to NDK 28.0.12433566 and compileSdk 36 (16 KB page-size alignment required by Google Play for targetSdk 35+)
 
 ## 1.0.2
 
@@ -25,4 +17,18 @@
 * Automatic degradation from CoreML to CPU when memory is low
 * Real-time monitoring with 200MB minimum threshold for iPhone 11's 4GB RAM
 * Graceful error handling with helpful user messages
-*  Memory cleanup triggered by iOS system notifications
+* Memory cleanup triggered by iOS system notifications
+
+## 1.0.1
+
+* Update Gradle version to 8.4.2
+* Update NDK version to 27.0.11902837
+* Support MacOS
+
+## 1.0.0
+
+* Optimizing performance
+* Update Dependencies
+* AGP8+ compatible
+* Support custom model download Host
+* See the example project for more details.

--- a/ios/Classes/whisper.cpp/whisper.cpp
+++ b/ios/Classes/whisper.cpp/whisper.cpp
@@ -400,7 +400,13 @@ struct whisper_vocab {
     id token_beg        = 50363; // begin timestamps
 
     bool is_multilingual() const {
-        return n_vocab == 51865;
+        // v2-family multilingual models have 51865 tokens; v3-family
+        // (large-v3, large-v3-turbo) add one language token -> 51866
+        return n_vocab >= 51865;
+    }
+
+    int num_languages() const {
+        return n_vocab - 51765 - (is_multilingual() ? 1 : 0);
     }
 };
 
@@ -995,13 +1001,17 @@ static bool whisper_model_load(struct whisper_model_loader * loader, whisper_con
         if (vocab.is_multilingual()) {
             vocab.token_eot++;
             vocab.token_sot++;
-            vocab.token_translate++;
-            vocab.token_transcribe++;
-            vocab.token_solm++;
-            vocab.token_prev++;
-            vocab.token_nosp++;
-            vocab.token_not++;
-            vocab.token_beg++;
+
+            // tokens after the language tokens shift by the number of extra
+            // languages: v2 has 99 (dt=1), v3-family has 100 (dt=2)
+            const int dt = vocab.num_languages() - 98;
+            vocab.token_translate  += dt;
+            vocab.token_transcribe += dt;
+            vocab.token_solm       += dt;
+            vocab.token_prev       += dt;
+            vocab.token_nosp       += dt;
+            vocab.token_not        += dt;
+            vocab.token_beg        += dt;
         }
 
         if (n_vocab < model.hparams.n_vocab) {
@@ -3145,7 +3155,8 @@ void whisper_free_params(struct whisper_full_params * params) {
 }
 
 int whisper_pcm_to_mel_with_state(struct whisper_context * ctx, struct whisper_state * state, const float * samples, int n_samples, int n_threads) {
-    if (!log_mel_spectrogram(*state, samples, n_samples, WHISPER_SAMPLE_RATE, WHISPER_N_FFT, WHISPER_HOP_LENGTH, WHISPER_N_MEL, n_threads, ctx->model.filters, false, state->mel)) {
+    // use the model's mel filter count (80 for v2-family, 128 for v3/turbo)
+    if (!log_mel_spectrogram(*state, samples, n_samples, WHISPER_SAMPLE_RATE, WHISPER_N_FFT, WHISPER_HOP_LENGTH, ctx->model.filters.n_mel, n_threads, ctx->model.filters, false, state->mel)) {
         log("%s: failed to compute mel spectrogram\n", __func__);
         return -1;
     }
@@ -3159,7 +3170,7 @@ int whisper_pcm_to_mel(struct whisper_context * ctx, const float * samples, int 
 
 // same as whisper_pcm_to_mel, but applies a Phase Vocoder to speed up the audio x2
 int whisper_pcm_to_mel_phase_vocoder_with_state(struct whisper_context * ctx, struct whisper_state * state, const float * samples, int n_samples, int n_threads) {
-    if (!log_mel_spectrogram(*state, samples, n_samples, WHISPER_SAMPLE_RATE, 2 * WHISPER_N_FFT, 2 * WHISPER_HOP_LENGTH, WHISPER_N_MEL, n_threads, ctx->model.filters, true, state->mel)) {
+    if (!log_mel_spectrogram(*state, samples, n_samples, WHISPER_SAMPLE_RATE, 2 * WHISPER_N_FFT, 2 * WHISPER_HOP_LENGTH, ctx->model.filters.n_mel, n_threads, ctx->model.filters, true, state->mel)) {
         log("%s: failed to compute mel spectrogram\n", __func__);
         return -1;
     }

--- a/ios/Classes/whisper_flutter_coreml.cpp
+++ b/ios/Classes/whisper_flutter_coreml.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <string>
 #include <thread>
+#include <mutex>
 #include <vector>
 #include <cmath>
 #include <iostream>
@@ -15,6 +16,13 @@
 #include "json/json.hpp"
 
 using json = nlohmann::json;
+
+// Model load (ggml weights + CoreML encoder) dominates short requests, so the
+// context is kept alive across calls and reloaded only when the model changes.
+// Freed on demand via the "releaseContext" request.
+static whisper_context *g_cached_ctx = nullptr;
+static std::string g_cached_model_path;
+static std::mutex g_ctx_mutex;
 
 char *jsonToChar(json jsonData) noexcept
 {
@@ -102,8 +110,26 @@ json transcribe(json jsonBody) noexcept
         params.seed = time(NULL);
     }
 
-    // whisper init
-    struct whisper_context *ctx = whisper_init_from_file(params.model.c_str());
+    // whisper init (cached across requests; serialized by the mutex)
+    std::lock_guard<std::mutex> ctx_lock(g_ctx_mutex);
+    if (g_cached_ctx == nullptr || g_cached_model_path != params.model)
+    {
+        if (g_cached_ctx != nullptr)
+        {
+            whisper_free(g_cached_ctx);
+            g_cached_ctx = nullptr;
+        }
+        g_cached_ctx = whisper_init_from_file(params.model.c_str());
+        g_cached_model_path = params.model;
+    }
+    struct whisper_context *ctx = g_cached_ctx;
+    if (ctx == nullptr)
+    {
+        g_cached_model_path.clear();
+        jsonResult["@type"] = "error";
+        jsonResult["message"] = "failed to load whisper model: " + params.model;
+        return jsonResult;
+    }
     std::string text_result = "";
     const auto fname_inp = params.audio;
     // WAV input
@@ -257,8 +283,8 @@ json transcribe(json jsonBody) noexcept
         }
     }
     jsonResult["text"] = text_result;
-    
-    whisper_free(ctx);
+
+    // ctx stays cached for the next request (see g_cached_ctx)
     return jsonResult;
 }
 extern "C"
@@ -288,6 +314,19 @@ extern "C"
             {
                 jsonResult["@type"] = "version";
                 jsonResult["message"] = "lib version: v1.0.1";
+                return jsonToChar(jsonResult);
+            }
+            if (jsonBody["@type"] == "releaseContext")
+            {
+                std::lock_guard<std::mutex> ctx_lock(g_ctx_mutex);
+                if (g_cached_ctx != nullptr)
+                {
+                    whisper_free(g_cached_ctx);
+                    g_cached_ctx = nullptr;
+                    g_cached_model_path.clear();
+                }
+                jsonResult["@type"] = "releaseContext";
+                jsonResult["message"] = "released";
                 return jsonToChar(jsonResult);
             }
             if (jsonBody["@type"] == "checkMemory")

--- a/lib/bean/request_bean.dart
+++ b/lib/bean/request_bean.dart
@@ -105,6 +105,22 @@ class VersionRequest with _$VersionRequest implements WhisperRequestDto {
   }
 }
 
+/// Frees the natively cached whisper context (model weights + CoreML
+/// encoder). Plain class (not freezed) — no fields, no codegen needed.
+class ReleaseContextRequest implements WhisperRequestDto {
+  const ReleaseContextRequest();
+
+  @override
+  String get specialType => "releaseContext";
+
+  @override
+  String toRequestString() {
+    return json.encode({
+      "@type": specialType,
+    });
+  }
+}
+
 @freezed
 class MemoryCheckRequest with _$MemoryCheckRequest implements WhisperRequestDto {
   const factory MemoryCheckRequest() = _MemoryCheckRequest;

--- a/lib/download_model.dart
+++ b/lib/download_model.dart
@@ -43,6 +43,14 @@ enum WhisperModel {
   String getPath(String dir) {
     return "$dir/ggml-$modelName.bin";
   }
+
+  /// Name used for CoreML encoder artifacts. Quantization only applies to
+  /// the ggml weights, so any "-qX_Y" suffix is stripped — this mirrors
+  /// whisper.cpp's whisper_get_coreml_path_encoder() lookup.
+  String get coreMLModelName {
+    final match = RegExp(r'-q\d_\d$').firstMatch(modelName);
+    return match != null ? modelName.substring(0, match.start) : modelName;
+  }
   
   /// Check if this model can run with available memory (MB)
   /// [hasCoreML] indicates if CoreML hardware acceleration is available
@@ -67,7 +75,7 @@ enum WhisperModel {
   bool hasCoreMLModel(String modelDir) {
     if (this == WhisperModel.none) return false;
     
-    final coreMLPath = '$modelDir/ggml-$modelName-encoder.mlmodelc';
+    final coreMLPath = '$modelDir/ggml-$coreMLModelName-encoder.mlmodelc';
     final coreMLDir = Directory(coreMLPath);
     
     return coreMLDir.existsSync() && coreMLDir.listSync().isNotEmpty;
@@ -195,7 +203,7 @@ Future<void> _downloadCoreMLModel({
 }) async {
   if (model == WhisperModel.none) return;
 
-  final coreMLFileName = 'ggml-${model.modelName}-encoder.mlmodelc';
+  final coreMLFileName = 'ggml-${model.coreMLModelName}-encoder.mlmodelc';
   final coreMLDir = Directory('$destinationPath/$coreMLFileName');
   final downloadKey = '${model.modelName}@$destinationPath';
 
@@ -408,11 +416,11 @@ Future<void> _downloadCoreMLModel({
     Uri coreMLUri;
     if (downloadHost == null || downloadHost.isEmpty) {
       coreMLUri = Uri.parse(
-        'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-${model.modelName}-encoder.mlmodelc.zip',
+        'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-${model.coreMLModelName}-encoder.mlmodelc.zip',
       );
     } else {
       coreMLUri = Uri.parse(
-        '$downloadHost/ggml-${model.modelName}-encoder.mlmodelc.zip',
+        '$downloadHost/ggml-${model.coreMLModelName}-encoder.mlmodelc.zip',
       );
     }
     

--- a/lib/whisper_flutter_coreml.dart
+++ b/lib/whisper_flutter_coreml.dart
@@ -226,6 +226,16 @@ class Whisper {
     return response.message;
   }
 
+  /// Free the natively cached whisper context (model weights + CoreML
+  /// encoder). Call when transcription is finished to reclaim memory; the
+  /// next transcribe() reloads the model automatically.
+  Future<void> releaseContext() async {
+    await _request(
+      whisperRequest: const ReleaseContextRequest(),
+      specificModel: WhisperModel.none,
+    );
+  }
+
   /// Check if CoreML model is available for hardware acceleration
   Future<bool> hasCoreMLSupport() async {
     if (!Platform.isIOS && !Platform.isMacOS) return false;

--- a/macos/Classes/whisper.cpp/whisper.cpp
+++ b/macos/Classes/whisper.cpp/whisper.cpp
@@ -400,7 +400,13 @@ struct whisper_vocab {
     id token_beg        = 50363; // begin timestamps
 
     bool is_multilingual() const {
-        return n_vocab == 51865;
+        // v2-family multilingual models have 51865 tokens; v3-family
+        // (large-v3, large-v3-turbo) add one language token -> 51866
+        return n_vocab >= 51865;
+    }
+
+    int num_languages() const {
+        return n_vocab - 51765 - (is_multilingual() ? 1 : 0);
     }
 };
 
@@ -995,13 +1001,17 @@ static bool whisper_model_load(struct whisper_model_loader * loader, whisper_con
         if (vocab.is_multilingual()) {
             vocab.token_eot++;
             vocab.token_sot++;
-            vocab.token_translate++;
-            vocab.token_transcribe++;
-            vocab.token_solm++;
-            vocab.token_prev++;
-            vocab.token_nosp++;
-            vocab.token_not++;
-            vocab.token_beg++;
+
+            // tokens after the language tokens shift by the number of extra
+            // languages: v2 has 99 (dt=1), v3-family has 100 (dt=2)
+            const int dt = vocab.num_languages() - 98;
+            vocab.token_translate  += dt;
+            vocab.token_transcribe += dt;
+            vocab.token_solm       += dt;
+            vocab.token_prev       += dt;
+            vocab.token_nosp       += dt;
+            vocab.token_not        += dt;
+            vocab.token_beg        += dt;
         }
 
         if (n_vocab < model.hparams.n_vocab) {
@@ -3133,7 +3143,8 @@ void whisper_free_params(struct whisper_full_params * params) {
 }
 
 int whisper_pcm_to_mel_with_state(struct whisper_context * ctx, struct whisper_state * state, const float * samples, int n_samples, int n_threads) {
-    if (!log_mel_spectrogram(*state, samples, n_samples, WHISPER_SAMPLE_RATE, WHISPER_N_FFT, WHISPER_HOP_LENGTH, WHISPER_N_MEL, n_threads, ctx->model.filters, false, state->mel)) {
+    // use the model's mel filter count (80 for v2-family, 128 for v3/turbo)
+    if (!log_mel_spectrogram(*state, samples, n_samples, WHISPER_SAMPLE_RATE, WHISPER_N_FFT, WHISPER_HOP_LENGTH, ctx->model.filters.n_mel, n_threads, ctx->model.filters, false, state->mel)) {
         log("%s: failed to compute mel spectrogram\n", __func__);
         return -1;
     }
@@ -3147,7 +3158,7 @@ int whisper_pcm_to_mel(struct whisper_context * ctx, const float * samples, int 
 
 // same as whisper_pcm_to_mel, but applies a Phase Vocoder to speed up the audio x2
 int whisper_pcm_to_mel_phase_vocoder_with_state(struct whisper_context * ctx, struct whisper_state * state, const float * samples, int n_samples, int n_threads) {
-    if (!log_mel_spectrogram(*state, samples, n_samples, WHISPER_SAMPLE_RATE, 2 * WHISPER_N_FFT, 2 * WHISPER_HOP_LENGTH, WHISPER_N_MEL, n_threads, ctx->model.filters, true, state->mel)) {
+    if (!log_mel_spectrogram(*state, samples, n_samples, WHISPER_SAMPLE_RATE, 2 * WHISPER_N_FFT, 2 * WHISPER_HOP_LENGTH, ctx->model.filters.n_mel, n_threads, ctx->model.filters, true, state->mel)) {
         log("%s: failed to compute mel spectrogram\n", __func__);
         return -1;
     }

--- a/macos/Classes/whisper_flutter_coreml.cpp
+++ b/macos/Classes/whisper_flutter_coreml.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <string>
 #include <thread>
+#include <mutex>
 #include <vector>
 #include <cmath>
 #include <iostream>
@@ -14,6 +15,13 @@
 #include "json/json.hpp"
 
 using json = nlohmann::json;
+
+// Model load (ggml weights + CoreML encoder) dominates short requests, so the
+// context is kept alive across calls and reloaded only when the model changes.
+// Freed on demand via the "releaseContext" request.
+static whisper_context *g_cached_ctx = nullptr;
+static std::string g_cached_model_path;
+static std::mutex g_ctx_mutex;
 
 char *jsonToChar(json jsonData) noexcept
 {
@@ -101,8 +109,26 @@ json transcribe(json jsonBody) noexcept
         params.seed = time(NULL);
     }
 
-    // whisper init
-    struct whisper_context *ctx = whisper_init_from_file(params.model.c_str());
+    // whisper init (cached across requests; serialized by the mutex)
+    std::lock_guard<std::mutex> ctx_lock(g_ctx_mutex);
+    if (g_cached_ctx == nullptr || g_cached_model_path != params.model)
+    {
+        if (g_cached_ctx != nullptr)
+        {
+            whisper_free(g_cached_ctx);
+            g_cached_ctx = nullptr;
+        }
+        g_cached_ctx = whisper_init_from_file(params.model.c_str());
+        g_cached_model_path = params.model;
+    }
+    struct whisper_context *ctx = g_cached_ctx;
+    if (ctx == nullptr)
+    {
+        g_cached_model_path.clear();
+        jsonResult["@type"] = "error";
+        jsonResult["message"] = "failed to load whisper model: " + params.model;
+        return jsonResult;
+    }
     std::string text_result = "";
     const auto fname_inp = params.audio;
     // WAV input
@@ -253,8 +279,8 @@ json transcribe(json jsonBody) noexcept
         }
     }
     jsonResult["text"] = text_result;
-    
-    whisper_free(ctx);
+
+    // ctx stays cached for the next request (see g_cached_ctx)
     return jsonResult;
 }
 extern "C"
@@ -284,6 +310,19 @@ extern "C"
             {
                 jsonResult["@type"] = "version";
                 jsonResult["message"] = "lib version: v1.0.1";
+                return jsonToChar(jsonResult);
+            }
+            if (jsonBody["@type"] == "releaseContext")
+            {
+                std::lock_guard<std::mutex> ctx_lock(g_ctx_mutex);
+                if (g_cached_ctx != nullptr)
+                {
+                    whisper_free(g_cached_ctx);
+                    g_cached_ctx = nullptr;
+                    g_cached_model_path.clear();
+                }
+                jsonResult["@type"] = "releaseContext";
+                jsonResult["message"] = "released";
                 return jsonToChar(jsonResult);
             }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: whisper_flutter_coreml
 description: A flutter library for offline speech-to-text conversion which use whisper.cpp models implementation for Android、iOS、macOS.
-version: 1.0.3
+version: 1.0.4
 repository: https://github.com/statecs/whisper_flutter_coreml
 issue_tracker: https://github.com/statecs/whisper_flutter_coreml/issues
 homepage: https://pub.dev/packages/whisper_flutter_coreml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,8 @@ dependencies:
   ffi: ^2.1.2
   flutter:
     sdk: flutter
-  freezed_annotation: any
-  json_annotation: any
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.9.0
   path_provider: ^2.1.3
   plugin_platform_interface: ^2.1.8
 


### PR DESCRIPTION
## Summary
- Cache the whisper context (ggml weights + CoreML encoder) in process-wide statics so it is no longer reloaded on every transcribe request; reload only when the model path changes
- Add a `releaseContext` request and Dart `Whisper.releaseContext()` to free the native context explicitly
- Support Whisper v3-family models (large-v3, large-v3-turbo)
- Align CoreML encoder naming with native lookup for quantized models
- Changelog entry and pinned annotation dependencies for 1.0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Whisper v3, including large-v3 and large-v3-turbo models.
  - Added cached transcription contexts for faster repeated requests.
  - Added a public method to release cached model resources when needed.
  - Improved CoreML artifact lookup for quantized models.

- **Bug Fixes**
  - Corrected multilingual token handling and mel-spectrogram processing across model versions.
  - Improved model-load error reporting.

- **Chores**
  - Updated Android build requirements.
  - Released version 1.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->